### PR TITLE
Fix readme, volume must be at /var/lib/tor

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ docker run -p 9001:9001 -p 9030:9030 -v /path/to/torrc:/etc/tor/torrc selaux/tor
 
 ## Persisting the Relay's Key
 
-To persist your relay's key you can mount a volume at ```/var/lib/docker```.
+To persist your relay's key you can mount a volume at ```/var/lib/tor```.
 The tor user inside the docker container has UID and GID set to 9001 if you
 want to set up permissions.
 
 ```
-docker run -p 9001:9001  -v /some/path/:/var/lib/docker selaux/tor-relay
+docker run -p 9001:9001  -v /some/path/:/var/lib/tor selaux/tor-relay
 ```


### PR DESCRIPTION
Hi,

thanks for the container :-)

I've just noticed that the docker volume to persist the relay's key, must be mounted to `/var/lib/tor` to take effect.  Hence the tiny correction to the README file.

cheers
  ~stesie
